### PR TITLE
Fixes deprecation warnings with latest version of airline

### DIFF
--- a/plugin/settings/airline.vim
+++ b/plugin/settings/airline.vim
@@ -10,6 +10,6 @@
 let g:airline#extensions#tabline#enabled = 1
 let g:airline_theme='base16'
 let g:airline_powerline_fonts = 1
-let g:airline_enable_fugitive=1
-let g:airline_enable_syntastic=1
+let g:airline#extensions#branch#enabled = 1
+let g:airline#extensions#syntastic#enabled = 1
 


### PR DESCRIPTION
Names for some of the settings were changed in recent versions of airline. This squashes deprecation warnings that appear whenever vim is started.