### PR TITLE
Fixes errors when running recent version of vim and editing SCSS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Plugins groups:
     - taxilian/vim-web-indent
   - HTML
     - HTML-AutoCloseTag
-    - ChrisYip/Better-CSS-Syntax-for-Vim
+    - hail2u/vim-css3-syntax
   - Ruby
     - tpope/vim-rails
   - Misc

--- a/vundles.vim
+++ b/vundles.vim
@@ -85,7 +85,7 @@ endif
 " HTML
 if count(g:vundles, 'html')
   Bundle 'HTML-AutoCloseTag'
-  Bundle 'ChrisYip/Better-CSS-Syntax-for-Vim'
+  Bundle 'hail2u/vim-css3-syntax'
   Bundle 'juvenn/mustache.vim'
 endif
 


### PR DESCRIPTION
See https://github.com/chrisyip/Better-CSS-Syntax-for-Vim/issues/9

Replaces dependency for prettifying CSS to more stable package. Maintainer even attests that the plugin doesn't adhere to vim's conventions with how the plugin should be structured.