### PR TITLE
base16 plugin updates

### DIFF
--- a/plugin/settings/colors.vim
+++ b/plugin/settings/colors.vim
@@ -8,7 +8,7 @@
 "
 
 if has("user_commands")
-  set t_Co=256
+  let base16colorspace=256
   if (match($LC_TERM_PROFILE, "light") != -1)
     set background=light
   else

--- a/vundles.vim
+++ b/vundles.vim
@@ -9,11 +9,12 @@
 
 " Vundle itself
 Bundle 'gmarik/vundle'
+" Required for settings
+Bundle 'chriskempson/base16-vim'
 
 " General
 if count(g:vundles, 'general')
   Bundle 'scrooloose/nerdtree'
-  Bundle 'chriskempson/base16-vim'
   Bundle 'YankRing.vim'
   let g:yankring_history_dir = $HOME.'/.vim/'
   let g:yankring_history_file = '.yankring_history'


### PR DESCRIPTION
Variable for setting 256 colors has changed. Now it must manually be set with `let base16colorspace=256`.

I also ran into some errors related to base16 not being installed when not installing the general vundle. See comment in #6 